### PR TITLE
Rewrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 
 npm-debug.log
 
+martinez.config.js
+

--- a/lib/martinez.js
+++ b/lib/martinez.js
@@ -61,6 +61,9 @@ localPaths.forEach(addLocal)
 if (options.allowInvalidCert)
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 
+if (config.rewrite)
+  app.use(addRewrite(config.rewrite))
+
 if (options.remote)
   app.use(forwardTo(options.remote))
 
@@ -68,17 +71,14 @@ console.log(`Listening on ${options.address}:${options.port}`)
 app.listen(options.port, options.address)
 
 function getConfig(filePath) {
-  let cfg
   try {
     fs.accessSync(filePath, fs.F_OK | fs.R_OK)
-    cfg = require(path.resolve(filePath))
+    return require(path.resolve(filePath))
   } catch (err) {
     // TODO: maybe filter the error message a bit...
     console.error(`error reading config file '${filePath}':`, err, '\nIgnoring config file!')
-    cfg = {}
+    return {}
   }
-
-  return cfg
 }
 
 function addLocal(filePath) {
@@ -87,17 +87,28 @@ function addLocal(filePath) {
   app.use(express.static(filePath))
 }
 
+function addRewrite(rules) {
+  return function rewrite(req, res, next) {
+    if (rules[req.path]) {
+      const processor = rules[req.path]
+      const resWrite = res.write
+      res.write = function (data) {
+        const body = data.toString('utf8')
+        resWrite.call(res, processor(body))
+      }
+    }
+    next()
+  }
+}
+
 function forwardTo(target) {
   const proxy = createProxy(target)
-
-  if (options.stripCookieDomain) stripCookieDomain(proxy)
-  if (config.rewrite) rewriteProxiedResponse(proxy, config.rewrite)
-
-  proxy.on('error', err => {
-    console.warn('error on proxied request:', err)
-  })
+  if (options.stripCookieDomain)
+    stripCookieDomain(proxy)
 
   return (req, res) => {
+    // FIXME: deal with zipped content in a better way?
+    if (config.rewrite) delete req.headers['accept-encoding']
     proxy.web(req, res)
   }
 }
@@ -107,19 +118,6 @@ function stripCookieDomain(proxy) {
     const setCookie = proxyRes.headers['set-cookie']
     if (setCookie)
       proxyRes.headers['set-cookie'] = setCookie.map(cookie => cookie.replace(/Domain=[^;]+;?/, ''))
-  })
-}
-
-function rewriteProxiedResponse(proxy, rules) {
-  proxy.on('proxyRes', proxyRes => {
-    const reqPath = proxyRes.req.path
-    if (rules[reqPath]) {
-      const processor = rules[reqPath]
-      const resWrite = proxyRes.write
-      proxyRes.write = function (data) {
-        resWrite.call(proxyRes, processor(data))
-      }
-    }
   })
 }
 
@@ -135,7 +133,14 @@ function createProxy(target) {
     proxyOptions.toProxy = true
   }
 
-  return httpProxy.createProxyServer(proxyOptions)
+  const proxy = httpProxy.createProxyServer(proxyOptions)
+
+  proxy.on('error', err => {
+    // TODO: better error reporting
+    console.warn('error on proxied request:', err)
+  })
+
+  return proxy
 }
 
 function sslAgentWithProxy(proxy, target) {

--- a/lib/martinez.js
+++ b/lib/martinez.js
@@ -2,17 +2,18 @@
 
 const fs = require('fs')
 const url = require('url')
+const path = require('path')
 
 const _ = require('lodash')
 const express = require('express')
 const httpProxy = require('http-proxy')
 const tunnel = require('tunnel')
 const options = require('yargs')
-  .usage('Usage: $0 --local local_dir1 [--local local_dir2] [--remote https://example.com]')
+  .usage(`Usage: $0 --local local_dir1 [--local local_dir2] [--remote https://example.com]
+  [--config martinez.config.js]`)
 
-  .demand('l').requiresArg(true)
+  .demand('l')
   .alias('l', 'local')
-  .nargs('l', 1)
   .describe('l', 'Local directory. You can provide more than one, files will be looked up in the order they were added')
 
   .number('p')
@@ -33,6 +34,9 @@ const options = require('yargs')
   .alias('x', 'proxy')
   .describe('proxy', 'Proxy to connect to remote resources')
 
+  .string('config')
+  .describe('config', 'Load configuration from the given file')
+
   .boolean('allow-invalid-cert')
   .describe('allow-invalid-cert', 'Accept invalid or self-signed SSL certs')
   .default('allow-invalid-cert', false)
@@ -41,7 +45,7 @@ const options = require('yargs')
   .describe('strip-cookie-domain', 'Remove `Domain` from cookies set from proxied remotes')
   .default('strip-cookie-domain', true)
 
-  .requiresArg(['l', 'p', 'a', 'r', 'x'])
+  .requiresArg(['l', 'p', 'a', 'r', 'x', 'config'])
   .version()
 
   .help('h')
@@ -49,6 +53,8 @@ const options = require('yargs')
   .argv
 
 const app = express()
+const config = getConfig(options.config)
+
 const localPaths = _.isArray(options.local) ? options.local : [ options.local ]
 localPaths.forEach(addLocal)
 
@@ -61,10 +67,24 @@ if (options.remote)
 console.log(`Listening on ${options.address}:${options.port}`)
 app.listen(options.port, options.address)
 
-function addLocal(path) {
+function getConfig(filePath) {
+  let cfg
+  try {
+    fs.accessSync(filePath, fs.F_OK | fs.R_OK)
+    cfg = require(path.resolve(filePath))
+  } catch (err) {
+    // TODO: maybe filter the error message a bit...
+    console.error(`error reading config file '${filePath}':`, err, '\nIgnoring config file!')
+    cfg = {}
+  }
+
+  return cfg
+}
+
+function addLocal(filePath) {
   // FIXME: better error handling, until then: throw
-  fs.accessSync(path, fs.F_R_OK)
-  app.use(express.static(path))
+  fs.accessSync(filePath, fs.F_OK | fs.R_OK | fs.X_OK)
+  app.use(express.static(filePath))
 }
 
 function forwardTo(target) {

--- a/lib/martinez.js
+++ b/lib/martinez.js
@@ -89,8 +89,9 @@ function addLocal(filePath) {
 
 function forwardTo(target) {
   const proxy = createProxy(target)
-  if (options.stripCookieDomain)
-    stripCookieDomain(proxy)
+
+  if (options.stripCookieDomain) stripCookieDomain(proxy)
+  if (config.rewrite) rewriteProxiedResponse(proxy, config.rewrite)
 
   proxy.on('error', err => {
     console.warn('error on proxied request:', err)
@@ -102,31 +103,44 @@ function forwardTo(target) {
 }
 
 function stripCookieDomain(proxy) {
-  proxy.on('proxyRes', (proxyRes) => {
+  proxy.on('proxyRes', proxyRes => {
     const setCookie = proxyRes.headers['set-cookie']
     if (setCookie)
       proxyRes.headers['set-cookie'] = setCookie.map(cookie => cookie.replace(/Domain=[^;]+;?/, ''))
   })
 }
 
+function rewriteProxiedResponse(proxy, rules) {
+  proxy.on('proxyRes', proxyRes => {
+    const reqPath = proxyRes.req.path
+    if (rules[reqPath]) {
+      const processor = rules[reqPath]
+      const resWrite = proxyRes.write
+      proxyRes.write = function (data) {
+        resWrite.call(proxyRes, processor(data))
+      }
+    }
+  })
+}
+
 function createProxy(target) {
-  const config = {
+  const proxyOptions = {
     target: target,
     changeOrigin: true,
     autoRewrite: true,
     secure: false // usually the local name won't compatible with remote cert
   }
   if (options.proxy) {
-    config.agent = sslAgentWithProxy(options.proxy, target)
-    config.toProxy = true
+    proxyOptions.agent = sslAgentWithProxy(options.proxy, target)
+    proxyOptions.toProxy = true
   }
 
-  return httpProxy.createProxyServer(config)
+  return httpProxy.createProxyServer(proxyOptions)
 }
 
 function sslAgentWithProxy(proxy, target) {
   const urlParts = url.parse(proxy)
-  const config = {
+  const agentOptions = {
     proxy: {
       host: urlParts.hostname,
       port: urlParts.port
@@ -134,6 +148,6 @@ function sslAgentWithProxy(proxy, target) {
   }
   const isHttps = url.parse(target).protocol === 'https:'
 
-  return isHttps ? tunnel.httpsOverHttp(config) : tunnel.httpOverHttp(config)
+  return isHttps ? tunnel.httpsOverHttp(agentOptions) : tunnel.httpOverHttp(agentOptions)
 }
 

--- a/lib/martinez.js
+++ b/lib/martinez.js
@@ -96,6 +96,8 @@ function addRewrite(rules) {
         const body = data.toString('utf8')
         resWrite.call(res, processor(body))
       }
+      // FIXME: find a proper way of calculating the new content-length for the modified body
+      if (res.headers) delete res.headers['content-length']
     }
     next()
   }


### PR DESCRIPTION
Initial implementation of content rewriting. This version removes support for compressed responses as soon as any rewriting is enabled, for **all** requests. This has terrible performance, and must be improved soon.

It also clears the `content-length` header for modified responses, which is not great.
